### PR TITLE
shady vitamin dealer 초안 번역

### DIFF
--- a/src/locales/ko/mystery-encounters/shady-vitamin-dealer-dialogue.json
+++ b/src/locales/ko/mystery-encounters/shady-vitamin-dealer-dialogue.json
@@ -1,27 +1,27 @@
 {
-  "intro": "A man in a dark coat approaches you.",
-  "speaker": "Shady Salesman",
-  "intro_dialogue": ".@d{16}.@d{16}.@d{16}$I've got the goods if you've got the money.$Make sure your Pokémon can handle it though.",
-  "title": "The Vitamin Dealer",
-  "description": "The man opens his jacket to reveal some Pokémon vitamins. The numbers he quotes seem like a really good deal. Almost too good...\nHe offers two package deals to choose from.",
-  "query": "Which deal will you choose?",
-  "invalid_selection": "Pokémon must be healthy enough.",
+  "intro": "검은 코트를 입은 남자가 다가왔다.",
+  "speaker": "수상한 상인",
+  "intro_dialogue": ".@d{16}.@d{16}.@d{16}$아-주 좋은 물건이 있는데, 관심 있어?$물론, 네 포켓몬이 이걸 감당할 수 있을지는 모르지만.",
+  "title": "영양제 딜러(?)",
+  "description": "남자가 코트를 살짝 열어 보여주자,\n코트 안쪽에 포켓몬 영양제들이 빼곡히 들어있습니다.\n그가 부른 가격은 아주 매력적입니다. 좋아도 너무 좋군요…\n그는 두가지 선택지를 제시했습니다.",
+  "query": "거래를 받아들일까요?",
+  "invalid_selection": "포켓몬이 충분히 건강하지 않습니다.",
   "option": {
     "1": {
-      "label": "The Cheap Deal",
-      "tooltip": "(-) Pay {{option1Money, money}}\n(-) Side Effects?\n(+) Chosen Pokémon Gains 2 Random Vitamins"
+      "label": "저렴한 거래",
+      "tooltip": "(-) {{option1Money, money}} 지불\n(-) 부작용?\n(+) 선택한 포켓몬이 2가지 무작위 영양제 효과를 얻음"
     },
     "2": {
-      "label": "The Pricey Deal",
-      "tooltip": "(-) Pay {{option2Money, money}}\n(+) Chosen Pokémon Gains 2 Random Vitamins"
+      "label": "비싼 거래",
+      "tooltip": "(-) {{option2Money, money}} 지불\n(+) 선택한 포켓몬이 2가지 무작위 영양제 효과를 얻음"
     },
     "3": {
-      "label": "Leave",
-      "tooltip": "(-) No Rewards",
-      "selected": "Heh, wouldn't have figured you for a coward."
+      "label": "떠난다",
+      "tooltip": "(-) 보상 없음",
+      "selected": "흥, 너같은 겁쟁이한테는 안 팔아."
     },
-    "selected": "The man hands you two bottles and quickly disappears.${{selectedPokemon}} gained {{boost1}} and {{boost2}} boosts!"
+    "selected": "남자는 영양제 두 병을 건넨 뒤,\n빠르게 사라졌다.${{selectedPokemon}}[[는]] {{boost1}}[[과]] {{boost2}} 효과를 얻었다!"
   },
-  "cheap_side_effects": "But the medicine had some side effects!$Your {{selectedPokemon}} takes some damage,\nand its Nature is changed to {{newNature}}!",
-  "no_bad_effects": "Looks like there were no side-effects from the medicine!"
+  "cheap_side_effects": "그런데 약이 부작용이 있는 것 같다!${{selectedPokemon}}[[가]] 약간 고통스러워 한다.\n성격이 {{newNature}}[[로]] 변해버렸다!",
+  "no_bad_effects": "딱히 부작용도 없는 것 같다!"
 }


### PR DESCRIPTION
영양제 딜러(?)
현재 효과 메시지가 영양제 이름으로 나오고 있어서 좀 직관적이지가 않은데, 이건 코드 이슈라 차후에 수정해주길 바라는게 좋겠네요. ( 2가지 효과가 중복일때도 별도 처리가 없어서 좀 어색 )

https://github.com/user-attachments/assets/de958dfd-b9ec-4f23-9d62-0bd608360acc

